### PR TITLE
Refactor DB engine setup

### DIFF
--- a/db.py
+++ b/db.py
@@ -1,0 +1,23 @@
+"""Database connection utilities."""
+import os
+from sqlalchemy import create_engine
+from sqlalchemy.engine import Engine
+from dotenv import load_dotenv
+
+load_dotenv()
+
+
+def _get_engine() -> Engine:
+    user = os.getenv("DB_USER", "etl_user")
+    password = os.getenv("DB_PASSWORD", "EtLpw123")
+    host = os.getenv("DB_HOST", "mariadb")
+    port = os.getenv("DB_PORT", "3306")
+    database = os.getenv("DB_NAME", "etl_db")
+
+    # Für TCP-Verbindung localhost → 127.0.0.1 erzwingen
+    if host == "localhost":
+        host = "127.0.0.1"
+
+    return create_engine(
+        f"mysql+mysqlconnector://{user}:{password}@{host}:{port}/{database}"
+    )

--- a/load.py
+++ b/load.py
@@ -1,24 +1,9 @@
 # load.py
-from typing import Any
 import pandas as pd
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
 
-
-# ----------  Verbindung  ----------
-def _get_engine() -> Any:
-    user     = "etl_user"
-    password = "EtLpw123"
-    host     = "mariadb"
-    port     = "3306"
-    database = "etl_db"
-
-    # Für TCP-Verbindung localhost → 127.0.0.1 erzwingen
-    if host == "localhost":
-        host = "127.0.0.1"
-
-    return create_engine(
-        f"mysql+mysqlconnector://{user}:{password}@{host}:{port}/{database}"
-    )
+from db import _get_engine
 
 
 # ----------  Laden in Staging  ----------
@@ -31,7 +16,7 @@ def load_to_staging_weather(
     """
     Legt die Staging-Tabelle für Wetterdaten neu an (DROP + CREATE) und lädt die Daten hinein.
     """
-    engine = _get_engine()
+    engine: Engine = _get_engine()
 
     with engine.begin() as conn:
         # Tabelle komplett neu anlegen

--- a/report.py
+++ b/report.py
@@ -1,7 +1,9 @@
 # report.py
-from typing import Any
 import pandas as pd
-from sqlalchemy import create_engine, text
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+from db import _get_engine
 
 
 # ----------  Report-SQL  ----------
@@ -19,26 +21,10 @@ _SQL_REPORT = text("""
 """)
 
 
-# ----------  DB-Verbindung  ----------
-def _get_engine() -> Any:
-    user     = "etl_user"
-    password = "EtLpw123"
-    host     = "mariadb"
-    port     = "3306"
-    database = "etl_db"
-
-    if host == "localhost":
-        host = "127.0.0.1"
-
-    return create_engine(
-        f"mysql+mysqlconnector://{user}:{password}@{host}:{port}/{database}"
-    )
-
-
 # ----------  Report abrufen  ----------
 def fetch_report() -> pd.DataFrame:
     """Liefert den vollständigen Report als DataFrame."""
-    engine = _get_engine()
+    engine: Engine = _get_engine()
     with engine.connect() as conn:
         return pd.read_sql(_SQL_REPORT, conn)
 


### PR DESCRIPTION
## Summary
- Centralize SQLAlchemy engine creation in new `db` module
- Read database credentials from environment and load `.env`
- Update loaders and reports to use typed shared engine

## Testing
- `python -m py_compile db.py load.py report.py`

------
https://chatgpt.com/codex/tasks/task_e_689881a8e778832797f48e8d9f156c5a